### PR TITLE
Serve static files with nginx

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
     container_name: vim-app
     volumes:
       - ./web-app/django:/virtual-instrument-museum/vim-app
+      - vim-static:/virtual-instrument-museum/static
     depends_on:
       postgres:
         condition: service_healthy
@@ -44,8 +45,14 @@ services:
       - HOST_NAME=${HOST_NAME}
     ports:
       - "8000:80"
+    volumes:
+      - vim-static:/virtual-instrument-museum/static
     depends_on:
       - app
 
 networks:
   vim-net:
+
+
+volumes:
+  vim-static:

--- a/nginx/vim.conf.template
+++ b/nginx/vim.conf.template
@@ -15,6 +15,10 @@ server {
   client_max_body_size 4G;
   server_name ${HOST_NAME};
 
+  location /static/ {
+    root /virtual-instrument-museum/;
+  }
+
   location / {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for; # pass client address to upstream server
     proxy_set_header X-Forwarded-Proto $scheme; # pass scheme to upstream server

--- a/web-app/django-startup.sh
+++ b/web-app/django-startup.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+python manage.py collectstatic --noinput
+
 if [[ $DEVELOPMENT = "true" ]]
 then
     python manage.py runserver_plus 0:8001

--- a/web-app/django/VIM/settings.py
+++ b/web-app/django/VIM/settings.py
@@ -131,9 +131,11 @@ USE_TZ = True
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.2/howto/static-files/
 
+STATIC_ROOT = "/virtual-instrument-museum/static"
 STATIC_URL = "static/"
-
-STATICFILES_DIRS = [BASE_DIR / "VIM" / "static"]
+STATICFILES_DIRS = [
+    BASE_DIR / "VIM" / "static",
+]
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/4.2/ref/settings/#default-auto-field


### PR DESCRIPTION
Closes #48.

Static files are collected into a docker volume that is shared between the `app` and `nginx` containers. Nginx then serves these static files. NOTE: this means all static files must be placed in static folders recognized by django (configurable in `settings.py`) and all references to static files (eg. in templates) should use the `/static/` url.