### PR TITLE
Add language button for instrument names

### DIFF
--- a/web-app/django/VIM/apps/instruments/static/instruments/css/index.css
+++ b/web-app/django/VIM/apps/instruments/static/instruments/css/index.css
@@ -5,6 +5,7 @@ h4 {
     color: #435334;
     font-size: 20px;
     font-weight: 700;
+    margin-bottom: 0;
 }
 
 h5 {
@@ -12,7 +13,7 @@ h5 {
 }
 
 hr {
-    border: 1.5px solid #435334;
+    color: #435334 !important;
     margin-top: 0;
 }
 
@@ -53,6 +54,9 @@ hr {
     border-radius: 30px;
 }
 
+.instrument-language {
+    overflow: visible;
+}
 .display-btn {
     font-weight: bold;
     color: #435334;

--- a/web-app/django/VIM/apps/instruments/static/instruments/css/index.css
+++ b/web-app/django/VIM/apps/instruments/static/instruments/css/index.css
@@ -54,9 +54,6 @@ hr {
     border-radius: 30px;
 }
 
-.instrument-language {
-    overflow: visible;
-}
 .display-btn {
     font-weight: bold;
     color: #435334;

--- a/web-app/django/VIM/apps/instruments/static/instruments/js/DisplaySettings.js
+++ b/web-app/django/VIM/apps/instruments/static/instruments/js/DisplaySettings.js
@@ -1,4 +1,3 @@
-
 const masonryBtn = document.getElementById("masonry-btn");
 // const listBtn = document.getElementById("list-btn");
 const stdBtn = document.getElementById("std-btn");
@@ -82,3 +81,23 @@ function setMasonryView() {
         masonry.layout();
     });
 }
+
+// Instrument badge settings
+const instrumentLanguage = document.querySelector("#instrument-language-element");
+const instrumentBadge = document.querySelector("#instrument-language-badge");
+
+updateInstrumentBadge();
+
+function updateInstrumentBadge() {
+    const hideInstrumentBadge = localStorage.getItem('hideInstrumentBadge') || false;
+    if (hideInstrumentBadge) {
+        instrumentBadge.style.display = "none";
+    } else {
+        instrumentBadge.style.display = "";
+    }
+}
+
+instrumentLanguage.addEventListener("click", function () {
+    localStorage.setItem("hideInstrumentBadge", true);
+    updateInstrumentBadge();
+});

--- a/web-app/django/VIM/apps/instruments/templates/instruments/includes/listView.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/includes/listView.html
@@ -15,7 +15,7 @@
         <a href="#" class="text-decoration-none">
           <h5 class="card-title notranslate">
             {% for instrumentname in instrument.instrumentname_set.all %}
-              {% if instrumentname.language.en_label == "english" %}
+              {% if instrumentname.language.en_label == active_language.en_label %}
                 {{ instrumentname.name|title }}
               {% endif %}
             {% endfor %}

--- a/web-app/django/VIM/apps/instruments/templates/instruments/includes/masonryView.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/includes/masonryView.html
@@ -10,7 +10,7 @@
         <div class="card-body pb-0 pt-0">
           <p class="card-title text-center notranslate ">
             {% for instrumentname in instrument.instrumentname_set.all %}
-              {% if instrumentname.language.en_label == "english" %}
+              {% if instrumentname.language.en_label == active_language.en_label %}
                 {{ instrumentname.name|title }}
               {% endif %}
             {% endfor %}

--- a/web-app/django/VIM/apps/instruments/templates/instruments/includes/stdView.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/includes/stdView.html
@@ -12,7 +12,7 @@
         <div class="card-body pb-0 pt-0">
           <p class="card-title text-center notranslate">
             {% for instrumentname in instrument.instrumentname_set.all %}
-              {% if instrumentname.language.en_label == "english" %}
+              {% if instrumentname.language.en_label == active_language.en_label %}
                 {{ instrumentname.name|title }}
               {% endif %}
             {% endfor %}

--- a/web-app/django/VIM/apps/instruments/templates/instruments/index.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/index.html
@@ -94,22 +94,35 @@ Instrument List
     
   <div class="col-lg-9 pt-3 body-container">
     <div class="navigation d-flex justify-content-between align-items-center">
-        <h4 class="ms-3 my-auto"><small>INSTRUMENT LIST</small></h4>
-        <div class="d-flex">
-          <button type="button" class="btn me-1 px-1 py-0 justify-content-center display-btn" id="page-setting-btn" data-bs-toggle="modal" data-bs-target="#paginationModal">
-            <i class="bi bi-gear"></i>
+      <div class="d-flex">
+        <h4 class="ms-3 my-auto me-2"><small>INSTRUMENT LIST</small></h4>
+        <div class="dropdown notranslate">
+          <button class="btn btn-warning dropdown-toggle mx-2 mb-0 btn-sm" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+            {{ active_language.autonym|title }}
           </button>
-          {% include "instruments/includes/pageSetting.html" %}
-          <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="masonry-btn">
-            <i class="bi bi-columns-gap"></i>
-          </button>
-          {% comment %} <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="list-btn" style="display:none;">
-            <i class="bi bi-view-list"></i>
-          </button> {% endcomment %}
-          <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="std-btn" style="display:none;">
-            <i class="bi bi-grid"></i>
-          </button>
+          <ul class="dropdown-menu">
+            {% for language in languages %}
+              <li><a class="dropdown-item" href="?language={{ language.en_label }}">{{ language.autonym|title }}</a></li>
+            {% endfor %}
+          </ul>
         </div>
+      </div>
+
+      <div class="d-flex">
+        <button type="button" class="btn me-1 px-1 py-0 justify-content-center display-btn" id="page-setting-btn" data-bs-toggle="modal" data-bs-target="#paginationModal">
+          <i class="bi bi-gear"></i>
+        </button>
+        {% include "instruments/includes/pageSetting.html" %}
+        <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="masonry-btn">
+          <i class="bi bi-columns-gap"></i>
+        </button>
+        {% comment %} <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="list-btn" style="display:none;">
+          <i class="bi bi-view-list"></i>
+        </button> {% endcomment %}
+        <button type="button" class="btn me-2 px-1 py-0 justify-content-center display-btn" id="std-btn" style="display:none;">
+          <i class="bi bi-grid"></i>
+        </button>
+      </div>
     </div>
     <hr>
     <div class="container py-3" id="body-content">

--- a/web-app/django/VIM/apps/instruments/templates/instruments/index.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/index.html
@@ -95,9 +95,9 @@ Instrument List
   <div class="col-lg-9 pt-3 body-container">
     <div class="navigation d-flex justify-content-between align-items-center">
       <div class="d-flex">
-        <h4 class="ms-3 my-auto me-2"><small>INSTRUMENT LIST</small></h4>
-        <div class="dropdown notranslate">
-          <button class="btn btn-warning dropdown-toggle mx-2 mb-0 btn-sm" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <h4 class="ms-3 me-2 my-auto"><small>INSTRUMENT LIST</small></h4>
+        <div class="dropdown mx-2 notranslate instrument-language">
+          <button class="btn btn-warning dropdown-toggle py-0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             {{ active_language.autonym|title }}
           </button>
           <ul class="dropdown-menu">
@@ -124,7 +124,7 @@ Instrument List
         </button>
       </div>
     </div>
-    <hr>
+    <hr class="mb-2 mx-2">
     <div class="container py-3" id="body-content">
       {% include "instruments/includes/masonryView.html" %}
       {% comment %} {% include "instruments/includes/listView.html" %} {% endcomment %}

--- a/web-app/django/VIM/apps/instruments/templates/instruments/index.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/index.html
@@ -96,9 +96,14 @@ Instrument List
     <div class="navigation d-flex justify-content-between align-items-center">
       <div class="d-flex">
         <h4 class="ms-3 me-2 my-auto"><small>INSTRUMENT LIST</small></h4>
-        <div class="dropdown mx-2 notranslate instrument-language">
-          <button class="btn btn-warning dropdown-toggle py-0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
+        <div class="dropdown mx-2 notranslate" id="instrument-language-element">
+          <button class="btn btn-warning dropdown-toggle position-relative py-0" type="button" data-bs-toggle="dropdown" aria-expanded="false">
             {{ active_language.autonym|title }}
+            <span id="instrument-language-badge" 
+              class="position-absolute top-0 start-95 translate-middle-y badge rounded-pill bg-secondary" 
+              style="--bs-bg-opacity: .5; display: none;">
+              Instrument name language
+            </span>
           </button>
           <ul class="dropdown-menu">
             {% for language in languages %}
@@ -177,6 +182,6 @@ Instrument List
 {% block script %}
 <script src="https://cdn.jsdelivr.net/npm/masonry-layout@4/dist/masonry.pkgd.min.js"></script>
 <script src="https://unpkg.com/imagesloaded@5/imagesloaded.pkgd.min.js"></script>
-<script src="{% static "instruments/js/DisplayMode.js" %}"></script>
+<script src="{% static "instruments/js/DisplaySettings.js" %}"></script>
 <script src="{% static "instruments/js/PaginationTools.js" %}"></script>
 {% endblock %}

--- a/web-app/django/VIM/apps/instruments/views/instrument_list.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_list.py
@@ -1,5 +1,5 @@
 from django.views.generic import ListView
-from VIM.apps.instruments.models import Instrument
+from VIM.apps.instruments.models import Instrument, Language
 
 
 class InstrumentList(ListView):
@@ -26,4 +26,17 @@ class InstrumentList(ListView):
         context = super().get_context_data(**kwargs)
         context["active_tab"] = "instruments"
         context["instrument_num"] = Instrument.objects.count()
+        context["languages"] = Language.objects.all()
+        active_language_en = self.request.session.get("active_language_en", None)
+        context["active_language"] = (
+            Language.objects.get(en_label=active_language_en)
+            if active_language_en
+            else Language.objects.get(en_label="english")  # default in English
+        )
         return context
+
+    def get(self, request, *args, **kwargs):
+        language_en = request.GET.get("language", None)
+        if language_en:
+            request.session["active_language_en"] = language_en
+        return super().get(request, *args, **kwargs)

--- a/web-app/django/VIM/static/css/app.css
+++ b/web-app/django/VIM/static/css/app.css
@@ -62,14 +62,6 @@ header {
     color: #435334;
 }
 
-.language-btn {
-    color:#435334;
-}
-
-.language-btn:focus {
-    border-color:#435334;
-}
-
 .dropdown-menu {
     background-color: #FAF1E4;
 }

--- a/web-app/django/VIM/static/js/GoogleTranslate.js
+++ b/web-app/django/VIM/static/js/GoogleTranslate.js
@@ -13,3 +13,22 @@ function googleTranslateElementInit() {
     const grandparent = parent.parentElement;
     grandparent.classList.add('h-100', 'd-flex', 'align-items-center');
 } 
+
+const pageLanguage = document.querySelector("#google_translate_element");
+const pageBadge = document.querySelector("#page-language-badge");
+
+updatePageBadge();
+
+function updatePageBadge() {
+    const hidePageBadge = localStorage.getItem('hidePageBadge') || false;
+    if (hidePageBadge) {
+        pageBadge.style.display = "none";
+    } else {
+        pageBadge.style.display = "";
+    }
+}
+
+pageLanguage.addEventListener("click", function () {
+    localStorage.setItem("hidePageBadge", true);
+    updatePageBadge();
+});

--- a/web-app/django/VIM/templates/404.html
+++ b/web-app/django/VIM/templates/404.html
@@ -6,5 +6,5 @@ Oops
 
 {% block content %}
 <h1>Oops</h1>
-<h2>{% trans "We can't seem to find the page you are looking for." %}</h2>
+<h2>We can't seem to find the page you are looking for.</h2>
 {% endblock%}

--- a/web-app/django/VIM/templates/base.html
+++ b/web-app/django/VIM/templates/base.html
@@ -38,7 +38,13 @@
 
         <div class="text-end d-flex">
           <button type="button" class="btn me-2 login-btn">Login</button>
-          <div id="google_translate_element" class="d-flex align-items-center"></div>
+          <div id="google_translate_element" class="d-flex align-items-center position-relative">
+            <span id="page-language-badge" 
+              class="position-absolute top-0 end-0 translate-middle-y badge rounded-pill bg-secondary"
+              style="--bs-bg-opacity: .5; display: none;">
+              Web page language
+            </span>
+          </div>
         </div>
       </div>
     </div>
@@ -56,7 +62,6 @@
   
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
    integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-
   <script src="{% static "/js/GoogleTranslate.js" %}"></script>
   <script type="text/javascript" src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
   {% block script %} {% endblock %}

--- a/web-app/django/VIM/templates/base.html
+++ b/web-app/django/VIM/templates/base.html
@@ -1,5 +1,5 @@
 {% load static %}
-{% load i18n %}
+
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -25,19 +25,19 @@
             </a>
           </li>
           <li class="nav-item"><a href="{% url "main:home" %}" class="nav-link px-2 text-decoration-none
-            {% if active_tab == 'home' %}active{% endif %}">{% trans "Home" %}</a></li>
+            {% if active_tab == 'home' %}active{% endif %}">Home</a></li>
           <li class="nav-item"><a href="{% url "instrument-list" %}" class="nav-link px-2 text-decoration-none
-            {% if active_tab == 'instruments' %}active{% endif %}">{% trans "Instruments" %}</a></li>
+            {% if active_tab == 'instruments' %}active{% endif %}">Instruments</a></li>
           <li class="nav-item"><a href="{% url "main:about" %}" class="nav-link px-2 text-decoration-none
-            {% if active_tab == 'about' %}active{% endif %}">{% trans "About" %}</a></li>
+            {% if active_tab == 'about' %}active{% endif %}">About</a></li>
         </ul>
 
         <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3" role="search">
-          <input type="search" class="form-control search-input" placeholder="{% trans 'Search...' %}" aria-label="Search">
+          <input type="search" class="form-control search-input" placeholder="Search..." aria-label="Search">
         </form>
 
         <div class="text-end d-flex">
-          <button type="button" class="btn me-2 login-btn">{% trans "Login" %}</button>
+          <button type="button" class="btn me-2 login-btn">Login</button>
           <div id="google_translate_element" class="d-flex align-items-center"></div>
         </div>
       </div>


### PR DESCRIPTION
Closes #73 

- Added the button on the instrument page instead of the navbar for two reasons:
  - the instrument list page is the only place shows the instrument names (or at least for now)
  - 2 language buttons in the navbar may confuse the user
- Added floating notes to show users what the language setting is about, they disappear after clicking

Open to any changes.

<img width="1429" alt="image" src="https://github.com/DDMAL/VIM/assets/74484576/cb6c1cf9-33a1-49a7-b578-d6a29065f1d3">



