### PR TITLE
ci: init pre-commit hook for code reformatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 23.1a1
+    hooks:
+      - id: black
+
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: v2.3.2
+    hooks:
+      - id: prettier
+        additional_dependencies: ["prettier@2.3.2"]
+        files: "\\.(js|jsx|ts|tsx|css|scss|less|json|yaml|yml|md)$"
+
+  - repo: https://github.com/djlint/djLint
+    rev: v1.34.1
+    hooks:
+      - id: djlint-reformat-django
+      - id: djlint-django


### PR DESCRIPTION
- Use black for python, djlint for html, prettier for css and js

Resolves: #117