### PR TITLE
feat: detail page UI rearrangement

### DIFF
--- a/web-app/django/VIM/apps/instruments/static/instruments/css/detail.css
+++ b/web-app/django/VIM/apps/instruments/static/instruments/css/detail.css
@@ -25,14 +25,20 @@
 }
 .detail-image {
   display: flex;
-  flex-direction: row;
+  flex-direction: column;
   flex-wrap: nowrap;
   justify-content: flex-start;
   align-items: flex-start;
 }
+.image-container {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: flex-start;
+  margin-bottom: 30px;
+}
 .instrument-image {
-  max-width: 50%;
-  margin-right: 10px;
+  max-width: 25%;
 }
 .detail-image-caption {
   display: flex;
@@ -96,4 +102,22 @@ th[scope='row'] {
 }
 .btn.publish {
   background-color: #28a745;
+}
+.btn-primary {
+  background-color: #435334;
+  border: 1px solid #435334;
+}
+.btn-primary:hover {
+  background-color: #9eb384;
+  border: 1px solid #9eb384;
+}
+.form-label {
+  color: #435334;
+}
+.image-header {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: nowrap;
+  justify-content: space-between;
+  align-items: flex-start;
 }

--- a/web-app/django/VIM/apps/instruments/templates/instruments/detail.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/detail.html
@@ -28,6 +28,112 @@
         <table class="table table-sm table-striped table-bordered">
           <tbody>
             <tr>
+              <th scope="row">Instrument Names in Different Languages</th>
+              <td>
+                <table class="table table-sm table-striped table-bordered">
+                  <thead>
+                    <tr>
+                      <th scope="col">
+                        <span class="name-form-item">Language</span>
+                      </th>
+                      <th scope="col">
+                        <span class="name-form-item">Name</span>
+                      </th>
+                      <th scope="col">
+                        <span class="name-form-item">Source</span>
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {% for instrumentname in instrument_names %}
+                      <tr>
+                        <td>
+                          <div class="name-form-item">
+                            <div class="name-field">
+                              <span class="view-field">{{ instrumentname.language.en_label }}</span>
+                              <input class="edit-field"
+                                     type="text"
+                                     value="{{ instrumentname.language.en_label }}" />
+                            </div>
+                            {% if user.is_authenticated %}
+                              <div class="button-group">
+                                <button class="btn edit">Edit</button>
+                                <button class="btn cancel">Cancel</button>
+                                <button class="btn publish">Publish</button>
+                              </div>
+                            {% endif %}
+                          </div>
+                        </td>
+                        <td>
+                          <div class="name-form-item">
+                            <div class="name-field">
+                              <span class="view-field">{{ instrumentname.name }}</span>
+                              <input class="edit-field" type="text" value="{{ instrumentname.name }}" />
+                            </div>
+                            {% if user.is_authenticated %}
+                              <div class="button-group">
+                                <button class="btn edit">Edit</button>
+                                <button class="btn cancel">Cancel</button>
+                                <button class="btn publish">Publish</button>
+                              </div>
+                            {% endif %}
+                          </div>
+                        </td>
+                        <td>
+                          <div class="name-form-item">
+                            <div class="name-field">
+                              <span class="view-field">{{ instrumentname.source_name }}</span>
+                              <input class="edit-field"
+                                     type="text"
+                                     value="{{ instrumentname.source_name }}" />
+                            </div>
+                            {% if user.is_authenticated %}
+                              <div class="button-group">
+                                <button class="btn edit">Edit</button>
+                                <button class="btn cancel">Cancel</button>
+                                <button class="btn publish">Publish</button>
+                              </div>
+                            {% endif %}
+                          </div>
+                        </td>
+                      </tr>
+                    {% endfor %}
+                  </tbody>
+                </table>
+              </td>
+            </tr>
+            <tr>
+              <th scope="row">
+                <div class="image-header">
+                  <span>Image</span>
+                  {% if user.is_authenticated %}
+                    <button type="button"
+                            class="btn btn-primary"
+                            data-bs-toggle="modal"
+                            data-bs-target="#uploadImageModal">
+                      Upload New Images
+                    </button>
+                    {% include "instruments/includes/imageUploadModal.html" %}
+
+                  {% endif %}
+                </div>
+              </th>
+              <td>
+                <div class="name-form-item">
+                  <div class="detail-image">
+                    <div class="image-container">
+                      <img src="{{ instrument.default_image.url }}"
+                           alt="{{ instrument.default_image.url }}"
+                           class="img-fluid border instrument-image" />
+                      <div class="detail-image-caption">
+                        <a href="{{ instrument.default_image.url }}" target="_blank">View image in full size</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </td>
+            </tr>
+            <tr>
               <th scope="row">Wikidata ID</th>
               <td>
                 <div class="name-form-item">
@@ -57,90 +163,6 @@
                     <a class="view-field"
                        href="https://vocabulary.mimo-international.com/InstrumentsKeywords/en/page/{{ mimo_class }}"
                        target="_blank">{{ instrument.mimo_class }}</a>
-                  </div>
-                </div>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Instrument Names in Different Languages</th>
-              <td>
-                <table class="table table-sm table-striped table-bordered">
-                  <thead>
-                    <tr>
-                      <th scope="col">
-                        <span class="name-form-item">Language</span>
-                      </th>
-                      <th scope="col">
-                        <span class="name-form-item">Name</span>
-                      </th>
-                      <th scope="col">
-                        <span class="name-form-item">Source</span>
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {% for instrumentname in instrument_names %}
-                      <tr>
-                        <td>
-                          <div class="name-form-item">
-                            <div class="name-field">
-                              <span class="view-field">{{ instrumentname.language.en_label }}</span>
-                              <input class="edit-field"
-                                     type="text"
-                                     value="{{ instrumentname.language.en_label }}" />
-                            </div>
-                            <div class="button-group">
-                              <button class="btn edit">Edit</button>
-                              <button class="btn cancel">Cancel</button>
-                              <button class="btn publish">Publish</button>
-                            </div>
-                          </div>
-                        </td>
-                        <td>
-                          <div class="name-form-item">
-                            <div class="name-field">
-                              <span class="view-field">{{ instrumentname.name }}</span>
-                              <input class="edit-field" type="text" value="{{ instrumentname.name }}" />
-                            </div>
-                            <div class="button-group">
-                              <button class="btn edit">Edit</button>
-                              <button class="btn cancel">Cancel</button>
-                              <button class="btn publish">Publish</button>
-                            </div>
-                          </div>
-                        </td>
-                        <td>
-                          <div class="name-form-item">
-                            <div class="name-field">
-                              <span class="view-field">{{ instrumentname.source_name }}</span>
-                              <input class="edit-field"
-                                     type="text"
-                                     value="{{ instrumentname.source_name }}" />
-                            </div>
-                            <div class="button-group">
-                              <button class="btn edit">Edit</button>
-                              <button class="btn cancel">Cancel</button>
-                              <button class="btn publish">Publish</button>
-                            </div>
-                          </div>
-                        </td>
-                      </tr>
-                    {% endfor %}
-                  </tbody>
-                </table>
-              </td>
-            </tr>
-            <tr>
-              <th scope="row">Image</th>
-              <td>
-                <div class="name-form-item">
-                  <div class="detail-image">
-                    <img src="{{ instrument.default_image.url }}"
-                         alt="{{ instrument.default_image.url }}"
-                         class="figure-img img-fluid rounded instrument-image" />
-                    <div class="detail-image-caption">
-                      <a href="{{ instrument.default_image.url }}" target="_blank">View image in full size</a>
-                    </div>
                   </div>
                 </div>
               </td>

--- a/web-app/django/VIM/apps/instruments/templates/instruments/includes/imageUploadModal.html
+++ b/web-app/django/VIM/apps/instruments/templates/instruments/includes/imageUploadModal.html
@@ -1,0 +1,31 @@
+<div class="modal fade"
+     id="uploadImageModal"
+     tabindex="-1"
+     aria-labelledby="uploadImageModalLabel"
+     aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h4 class="modal-title" id="uploadImageModalLabel">Upload New Images</h4>
+        <button type="button"
+                class="btn-close"
+                data-bs-dismiss="modal"
+                aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <form method="post" enctype="multipart/form-data">
+          {% csrf_token %}
+          <div class="mb-3">
+            <label for="imageUpload" class="form-label">Choose images to upload</label>
+            <input class="form-control"
+                   type="file"
+                   id="imageUpload"
+                   name="images"
+                   multiple />
+          </div>
+          <button type="submit" class="btn btn-primary">Upload</button>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
- Initialize image uploading modal;
- make `image uploading` & `Edit` buttons only display when users log in;
- Adjust row orders: `Instrument Names in Different Languages` on the top; then `Image`; `Wikidata ID`, `Hornbostel-Sachs Classification` and `MIMO Classification` at the bottom;
- Images should be smaller in the detail page;
- UI should support displaying more than one images in the future;

Resolves: #128