### PR TITLE
Remove opening slash from script src paths in `base.html`

### DIFF
--- a/web-app/django/VIM/templates/base.html
+++ b/web-app/django/VIM/templates/base.html
@@ -102,10 +102,10 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
             integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
             crossorigin="anonymous"></script>
-    <script src="{% static "/js/GoogleTranslate.js" %}"></script>
+    <script src="{% static "js/GoogleTranslate.js" %}"></script>
     <script type="text/javascript"
             src="//translate.google.com/translate_a/element.js?cb=googleTranslateElementInit"></script>
-    <script src="{% static "/js/LanguageTooltip.js" %}"></script>
+    <script src="{% static "js/LanguageTooltip.js" %}"></script>
     {% block scripts %}
     {% endblock scripts %}
 


### PR DESCRIPTION
Parameters to the `static` template tag should be relative paths to avoid a `SuspiciousFileOperation` exception. See comments of #143 for details.