### PR TITLE
Redirect 301 on `nginx` from VIM to UMIL

### DIFF
--- a/nginx/vim.conf.template
+++ b/nginx/vim.conf.template
@@ -15,7 +15,7 @@ server {
   server_name vim.staging.simssa.ca;
 
   // Nginx docs: https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri ($scheme is right below it)
-  return 301 $scheme:${HOST_NAME}$request_uri;
+  return 301 $scheme://${HOST_NAME}$request_uri;
 }
 
 

--- a/nginx/vim.conf.template
+++ b/nginx/vim.conf.template
@@ -1,13 +1,22 @@
-  upstream vim-app {
-    # define the vim-app upstream server
-    server vim-app:8001 fail_timeout=0;
-  }
+upstream vim-app {
+  # define the vim-app upstream server
+  server vim-app:8001 fail_timeout=0;
+}
 
-  server {
-    # if no host match, close connection
-    listen 80 default_server;
-    return 444;
-  }
+server {
+  # if no host match, close connection
+  listen 80 default_server;
+  return 444;
+}
+
+server {
+  listen 80;
+  client_max_body_size 4G;
+  server_name vim.staging.simssa.ca;
+
+  // Nginx docs: https://nginx.org/en/docs/http/ngx_http_core_module.html#var_request_uri ($scheme is right below it)
+  return 301 $scheme:${HOST_NAME}$request_uri;
+}
 
 
 server {


### PR DESCRIPTION
- Forward all requests from
  - Staging server: `vim.staging.simssa.ca` to `umil.staging.linkedmusic.ca`
  - Production: `vim.simssa.ca` to `umil.linkedmusic.ca`
- Tested on staging server and it works fine: https://vim.staging.simssa.ca immediately goes to https://umil.staging.linkedmusic.ca
- Remove spaces for formatting consistency

---
- The forward rule is currently hardcoded for the incoming old domain. Should we add another variable to `.env`?
- Related to #162 
