### PR TITLE
build: set `STATICFILES_DIR` for prod mode only

### DIFF
--- a/web-app/django/VIM/settings.py
+++ b/web-app/django/VIM/settings.py
@@ -136,9 +136,11 @@ USE_TZ = True
 
 STATIC_ROOT = "/virtual-instrument-museum/static/"
 STATIC_URL = "static/"
-STATICFILES_DIRS = [
-    ROOT_DIR / "frontend" / "dist",
-]
+
+if not IS_DEVELOPMENT:
+    STATICFILES_DIRS = [
+        ROOT_DIR / "frontend" / "dist",
+    ]
 
 DJANGO_VITE = {
     "default": {


### PR DESCRIPTION
- Frontend files are built to `web-app/frontend/dist/` in prod mode only. This should resolve the path doesn't exist error in development mode.

refs: #224