### PR TITLE
Remove trailing spaces that interrupt CD Actions

### DIFF
--- a/.github/workflows/cd_prod.yml
+++ b/.github/workflows/cd_prod.yml
@@ -29,7 +29,7 @@ jobs:
              sudo git branch -v"
       - name: Checkout to `main` branch and pull new changes 
         run: |
-          ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \ 
+          ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST_PROD }} ${{ secrets.USERNAME }}@${{ secrets.HOST_PROD }} \
             "cd /virtual_instrument_museum &&
              sudo git checkout main &&
              sudo git pull origin main"

--- a/.github/workflows/cd_stage.yml
+++ b/.github/workflows/cd_stage.yml
@@ -31,7 +31,7 @@ jobs:
              sudo git branch --all -v"
       - name: Fetch on dev branch
         run: |
-          ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST2 }} ${{ secrets.USERNAME }}@${{ secrets.HOST }} \ 
+          ssh -J ${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST1 }},${{ secrets.PROXY_USERNAME }}@${{ secrets.PROXY_HOST2 }} ${{ secrets.USERNAME }}@${{ secrets.HOST }} \
             "cd /virtual_instrument_museum &&
              sudo git fetch origin develop &&
              sudo git merge origin/develop"


### PR DESCRIPTION
Removed a space in staging and production CD.

I made an small oopsie that makes the command invalid and fails Github Action run.