### PR TITLE
Create a persistent volume for Solr

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -63,6 +63,7 @@ services:
       - "8983:8983"
     volumes:
       - umil-solr:/var/solr
+      - ./solr/cores:/var/solr/data
 
 networks:
   vim-net:

--- a/solr/Dockerfile
+++ b/solr/Dockerfile
@@ -1,3 +1,2 @@
 FROM solr:9.2.1
 ENV SOLR_SECURITY_MANAGER_ENABLED=false
-COPY --chown=solr:solr ./cores /var/solr/data


### PR DESCRIPTION
Resolves #354 

This change helps keeping the HBS classifications on Solr so we don't have to perform "python manage.py index_data" everytime the docker containers are `docker compose down`-ed. 

Note that `docker compose stop` doesn't delete these HBS classifications.

Reference docs: https://solr.apache.org/guide/solr/latest/deployment-guide/solr-in-docker.html
