### PR TITLE
fix: move count num outside of hbs facet list for google translate

### DIFF
--- a/web-app/django/VIM/templates/instruments/index.html
+++ b/web-app/django/VIM/templates/instruments/index.html
@@ -58,12 +58,11 @@
             <ul class="list-group">
               {% for hbs_facet_item in hbs_facets %}
                 <a href="{{ hbs_facet_item.url }}" class="text-decoration-none">
-                  <li class="list-group-item d-flex justify-content-between p-0 {% if hbs_facet_item.is_active %}active{% endif %}"
-                      current-value="{{ hbs_facet_item.value }}">
+                  <li class="list-group-item d-flex justify-content-between p-0 {% if hbs_facet_item.is_active %}active{% endif %}">
                     {% if hbs_facet_item.name == 'Unclassified' %}
-                      <span class="text-start">{{ hbs_facet_item.name }} ({{ hbs_facet_item.count }})</span>
+                      <span class="text-start">{{ hbs_facet_item.name }}</span> ({{ hbs_facet_item.count }})
                     {% else %}
-                      <span class="text-start">{{ hbs_facet_item.value }} - {{ hbs_facet_item.name }} ({{ hbs_facet_item.count }})</span>
+                      <span class="text-start">{{ hbs_facet_item.value }} - {{ hbs_facet_item.name }} </span> ({{ hbs_facet_item.count }})
                     {% endif %}
                   </li>
                 </a>


### PR DESCRIPTION
- Google translate doesn't work well with numbers. The best practice is to only put human-readable part in a separate span.
- This is needed to make sure that all the hbs items can be translated well.

refs: #393

For Urdu:

<img width="268" height="321" alt="image" src="https://github.com/user-attachments/assets/ae473b45-77ea-4375-8eda-ec0871c6b819" />

For Arabic:

<img width="263" height="318" alt="image" src="https://github.com/user-attachments/assets/9491368c-76b7-4df2-a704-fa88d40ae1e2" />
