### PR TITLE
feat(solr): add exact-match field and ranking results

### DIFF
--- a/solr/cores/conf/schema.xml
+++ b/solr/cores/conf/schema.xml
@@ -79,11 +79,27 @@
             <filter class="solr.LowerCaseFilterFactory" />
         </analyzer>
     </fieldType>
-  
+
+    <!-- Exact match text field with term vectors -->
+    <fieldType name="text_vector" class="solr.TextField" positionIncrementGap="100" termVectors="true">
+        <analyzer type="index">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory" />
+        </analyzer>
+        <analyzer type="query">
+            <tokenizer class="solr.KeywordTokenizerFactory"/>
+            <filter class="solr.LowerCaseFilterFactory" />
+        </analyzer>
+    </fieldType>
+
+
    <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
     <!-- Define the new text field for queries -->
     <field name="text" type="text_general" indexed="true" stored="true" multiValued="true"/>
+
+    <!-- exact match field -->
+    <field name="text_exact" type="text_vector" indexed="true" stored="true" multiValued="true"/>
 
     <!-- Define the field for storing the thumbnail URL -->
     <field name="thumbnail_url" type="string" stored="true" indexed="false" />
@@ -91,4 +107,5 @@
     <!-- Copy field directives for aggregating values into the text field -->
     <copyField source="wikidata_id_s" dest="text"/>
     <copyField source="*_ss" dest="text" />
+    <copyField source="*_ss" dest="text_exact" />
 </schema>

--- a/solr/cores/conf/schema.xml
+++ b/solr/cores/conf/schema.xml
@@ -68,8 +68,8 @@
         </analyzer>
     </fieldType>
 
-    <!-- Exact match text field with term vectors -->
-    <fieldType name="text_vector" class="solr.TextField" positionIncrementGap="100" termVectors="true">
+    <!-- Exact match text field -->
+    <fieldType name="text_vector" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.KeywordTokenizerFactory"/>
             <filter class="solr.LowerCaseFilterFactory" />

--- a/solr/cores/conf/schema.xml
+++ b/solr/cores/conf/schema.xml
@@ -55,24 +55,12 @@
 
     <fieldType name="random" class="solr.RandomSortField" indexed="true" />
 
+    <!-- For general text with ngram for flexible search -->
     <fieldType name="text_general" class="solr.TextField" positionIncrementGap="100">
         <analyzer type="index">
             <tokenizer class="solr.StandardTokenizerFactory" />
             <filter class="solr.LowerCaseFilterFactory" />
             <filter class="solr.NGramFilterFactory" minGramSize="1" maxGramSize="15" />
-        </analyzer>
-        <analyzer type="query">
-            <tokenizer class="solr.StandardTokenizerFactory" />
-            <filter class="solr.LowerCaseFilterFactory" />
-        </analyzer>
-    </fieldType>
-    <!-- Just like text_general except it reverses the characters of
-	 each token, to enable more efficient leading wildcard queries. -->
-    <fieldType name="text_general_rev" class="solr.TextField" positionIncrementGap="100">
-        <analyzer type="index">
-            <tokenizer class="solr.StandardTokenizerFactory" />
-            <filter class="solr.LowerCaseFilterFactory" />
-            <filter class="solr.ReversedWildcardFilterFactory" withOriginal="true" maxPosAsterisk="3" maxPosQuestion="2" maxFractionAsterisk="0.33" />
         </analyzer>
         <analyzer type="query">
             <tokenizer class="solr.StandardTokenizerFactory" />
@@ -95,17 +83,18 @@
 
    <fieldtype name="ignored" stored="false" indexed="false" multiValued="true" class="solr.StrField" />
 
-    <!-- Define the new text field for queries -->
-    <field name="text" type="text_general" indexed="true" stored="true" multiValued="true"/>
+    <!-- Define the new text field for ngram queries -->
+    <field name="text_ngram" type="text_general" indexed="true" stored="false" multiValued="true"/>
 
-    <!-- exact match field -->
-    <field name="text_exact" type="text_vector" indexed="true" stored="true" multiValued="true"/>
+    <!-- Define the new text field for exact match queries -->
+    <field name="text_exact" type="text_vector" indexed="true" stored="false" multiValued="true"/>
 
     <!-- Define the field for storing the thumbnail URL -->
     <field name="thumbnail_url" type="string" stored="true" indexed="false" />
 
     <!-- Copy field directives for aggregating values into the text field -->
-    <copyField source="wikidata_id_s" dest="text"/>
-    <copyField source="*_ss" dest="text" />
+    <copyField source="*_ss" dest="text_ngram" />
+
+    <copyField source="wikidata_id_s" dest="text_exact"/>
     <copyField source="*_ss" dest="text_exact" />
 </schema>

--- a/solr/cores/conf/solrconfig.xml
+++ b/solr/cores/conf/solrconfig.xml
@@ -71,9 +71,12 @@
         <lst name="defaults">
             <str name="echoParams">explicit</str>
             <int name="rows">10</int>
+            <str name="defType">edismax</str>
             <str name="df">text</str>
+            <str name="qf">text_exact^2 text</str>
         </lst>
     </requestHandler>
+
 
     <!-- A request handler that returns indented JSON by default -->
     <requestHandler name="/query" class="solr.SearchHandler">

--- a/solr/cores/conf/solrconfig.xml
+++ b/solr/cores/conf/solrconfig.xml
@@ -72,8 +72,10 @@
             <str name="echoParams">explicit</str>
             <int name="rows">10</int>
             <str name="defType">edismax</str>
-            <str name="df">text_exact text_ngram</str>
-            <str name="qf">text_exact^2 text_ngram</str>
+             <arr name="qf">
+                <str>text_exact^2</str>
+                <str>text_ngram</str>
+            </arr>
         </lst>
     </requestHandler>
 

--- a/solr/cores/conf/solrconfig.xml
+++ b/solr/cores/conf/solrconfig.xml
@@ -72,8 +72,8 @@
             <str name="echoParams">explicit</str>
             <int name="rows">10</int>
             <str name="defType">edismax</str>
-            <str name="df">text</str>
-            <str name="qf">text_exact^2 text</str>
+            <str name="df">text_exact text_ngram</str>
+            <str name="qf">text_exact^2 text_ngram</str>
         </lst>
     </requestHandler>
 


### PR DESCRIPTION
- In #407, the ranking and fuzzy matching of search results were discussed. The system previously used n-gram matching to compare the query with language labels.
- This adds exact matching which, in contrast to n-gram matching, requires an exact match of the term.
- In the final results, exact matches are weighted twice as strongly as n-gram matches.