### PR TITLE
fix: do not show facet counts if it is zero

### DIFF
--- a/web-app/django/VIM/apps/instruments/views/instrument_list.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_list.py
@@ -322,6 +322,7 @@ class InstrumentList(TemplateView):
                 )
                 if value in all_facets:
                     all_facets[value]["count"] = hbs_cat["count"]
+
         else:
             # No contextual facet data, use the all categories counts directly
             for hbs_cat in all_categories_data:
@@ -331,7 +332,7 @@ class InstrumentList(TemplateView):
                     else hbs_cat["value"]
                 )
                 if value in all_facets:
-                    all_facets[value]["count"] = hbs_cat["count"]
+                    all_facets[value]["count"] = 0
 
         # Convert to list and sort
         hbs_facet_list = sorted(

--- a/web-app/django/VIM/templates/instruments/index.html
+++ b/web-app/django/VIM/templates/instruments/index.html
@@ -60,9 +60,11 @@
                 <a href="{{ hbs_facet_item.url }}" class="text-decoration-none">
                   <li class="list-group-item d-flex justify-content-between p-0 {% if hbs_facet_item.is_active %}active{% endif %}">
                     {% if hbs_facet_item.name == 'Unclassified' %}
-                      <span class="text-start">{{ hbs_facet_item.name }}</span> ({{ hbs_facet_item.count }})
+                      <span class="text-start">{{ hbs_facet_item.name }}</span>
+                      {% if hbs_facet_item.count %}({{ hbs_facet_item.count }}){% endif %}
                     {% else %}
-                      <span class="text-start">{{ hbs_facet_item.value }} - {{ hbs_facet_item.name }} </span> ({{ hbs_facet_item.count }})
+                      <span class="text-start">{{ hbs_facet_item.value }} - {{ hbs_facet_item.name }} </span>
+                      {% if hbs_facet_item.count %}({{ hbs_facet_item.count }}){% endif %}
                     {% endif %}
                   </li>
                 </a>


### PR DESCRIPTION
- put `all_facets[value]["count"] = 0` to when there is no contextual facet data to show zero when query does not match
- in `index.html` show count if it is more than zero

resolved https://github.com/DDMAL/UMIL/issues/414