### PR TITLE
fix: add notranslate to UMIL name

### DIFF
--- a/web-app/django/VIM/templates/base.html
+++ b/web-app/django/VIM/templates/base.html
@@ -60,7 +60,7 @@
             <ul class="navbar-nav me-lg-auto mx-auto mx-lg-0 text-center text-lg-start pb-1">
               <li class="nav-item">
                 <a href="{% url "main:home" %}"
-                   class="nav-link {% if active_tab == 'home' %}active{% endif %}">UMIL</a>
+                   class="nav-link notranslate {% if active_tab == 'home' %}active{% endif %}">UMIL</a>
               </li>
               <li class="nav-item">
                 <a href="{% url "instrument-list" %}"


### PR DESCRIPTION
Before:

<img width="536" height="205" alt="Screenshot 2025-11-19 at 1 27 56 PM" src="https://github.com/user-attachments/assets/28913d52-aa30-4dac-a081-7f1e9b03f3ec" />
