### PR TITLE
fix: standardize titles by using Wikidata entries

### DIFF
--- a/web-app/django/VIM/apps/instruments/views/instrument_list.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_list.py
@@ -59,7 +59,7 @@ class InstrumentNameSet:
 
     def get_display_names_str(self) -> str:
         sorted_names = sorted(self.all(), key=lambda x: not x.umil_label)
-        name_list = [n.name.title() for n in sorted_names]
+        name_list = [n.name for n in sorted_names]
         return " | ".join(name_list)
 
 

--- a/web-app/django/VIM/templates/instruments/detail.html
+++ b/web-app/django/VIM/templates/instruments/detail.html
@@ -4,7 +4,7 @@
 {% load django_vite %}
 
 {% block title %}
-  {{ active_instrument_label.name|title }}
+  {{ active_instrument_label.name }}
 {% endblock title %}
 
 {% block ts_files %}
@@ -22,7 +22,7 @@
   <div class="container d-flex align-items-center justify-content-center min-vh-80 py-4">
     <div class="container-border bg-white p-4 d-flex flex-column align-items-center flex-nowrap">
       <div class="w-100">
-        <h2 class="notranslate">{{ active_instrument_label.name|title }}</h2>
+        <h2 class="notranslate">{{ active_instrument_label.name }}</h2>
         <hr class="w-100 mt-0" />
       </div>
       <div class="w-100">
@@ -234,7 +234,7 @@
                               class="btn btn-primary"
                               data-bs-toggle="modal"
                               data-bs-target="#addNameModal"
-                              data-instrument-name="{{ active_instrument_label.name | title }}"
+                              data-instrument-name="{{ active_instrument_label.name }}"
                               data-instrument-wikidata-id="{{ instrument.wikidata_id }}"
                               data-instrument-pk="{{ instrument.pk }}">
                         Add Instrument Name


### PR DESCRIPTION
- avoid general capitalization rules that produce incorrect results
- avoid hard-coded logic for specific languages
- rely on original Wikidata entries for accurate casing

resolves https://github.com/DDMAL/UMIL/issues/425