### PR TITLE
fix: adjust table direction when translated to rtl

### DIFF
--- a/web-app/django/VIM/templates/instruments/detail.html
+++ b/web-app/django/VIM/templates/instruments/detail.html
@@ -97,7 +97,7 @@
                               <span class="view-field flex-grow-1 notranslate force-ltr">{{ lang.en_label }}</span>
                             </div>
                           </td>
-                          <td>
+                          <td class="text-start">
                             <div class="d-flex flex-row justify-content-between align-items-center gap-2 edit-container"
                                  dir="{{ lang.html_direction }}">
                               <div>
@@ -105,10 +105,10 @@
                               </div>
                             </div>
                           </td>
-                          <td>
+                          <td class="text-start">
                             <div class="d-flex flex-row justify-content-between align-items-center gap-2 edit-container"
                                  dir="{{ lang.html_direction }}">
-                              <div class="alias-list">
+                              <div class="alias-list d-flex flex-wrap gap-1">
                                 {% for alias in names.aliases %}
                                   <span class="alias-item notranslate">{{ alias.name }}</span>
                                 {% endfor %}
@@ -163,19 +163,24 @@
                       <!-- Language -->
                       <div class="mb-1">
                         <div class="fw-bold text-muted small">Language</div>
-                        <span class="view-field">{{ lang.en_label }}</span>
+                        <div class="force-ltr notranslate">
+                          <span class="view-field">{{ lang.en_label }}</span>
+                        </div>
                       </div>
                       <!-- Name -->
                       <div class="mb-1">
                         <div class="fw-bold text-muted small">Name</div>
-                        <span class="view-field notranslate">
-                          <div dir="{{ lang.html_direction }}">{{ names.label.name }}</div>
-                        </span>
+                        <div class="d-flex flex-row notranslate" dir="{{ lang.html_direction }}">
+                          <div>
+                            <span class="view-field text-start">{{ names.label.name }}</span>
+                          </div>
+                        </div>
                       </div>
                       <!-- Aliases -->
                       <div class="mb-1">
                         <div class="fw-bold text-muted small">Alias</div>
-                        <div class="alias-list" dir="{{ lang.html_direction }}">
+                        <div class="alias-list d-flex flex-wrap gap-1 text-start notranslate"
+                             dir="{{ lang.html_direction }}">
                           {% for alias in names.aliases %}
                             <span class="alias-item">{{ alias.name }}</span>
                           {% endfor %}

--- a/web-app/frontend/assets/scss/instruments/index.scss
+++ b/web-app/frontend/assets/scss/instruments/index.scss
@@ -53,12 +53,6 @@ h4 {
   color: $umil-green-dark !important;
 }
 
-.alias-list {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-}
-
 /* list view */
 // .list-item-container {
 //   min-height: 200px;


### PR DESCRIPTION
- Add `notranslate` to metadata
- Add `force-ltr` to language name
- Fix `dir="{{ lang.html_direction }}"` having no effect on alias list with multiple lines by defining `.alias-list`

Before:
<img width="600" height="300" alt="Im2" src="https://github.com/user-attachments/assets/98c4cf4c-b8f5-4856-bafb-4895d3625cda" />

After:
<img width="600" height="300" alt="Im1" src="https://github.com/user-attachments/assets/49bd0815-15bf-4c16-8c24-900d4717753b" />
