### PR TITLE
feat: add force-rtl utilities for forced-ltr contexts

### DIFF
--- a/web-app/django/VIM/templates/base.html
+++ b/web-app/django/VIM/templates/base.html
@@ -71,7 +71,7 @@
                    class="nav-link {% if active_tab == 'about' %}active{% endif %}">About</a>
               </li>
             </ul>
-            <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3"
+            <form class="col-12 col-lg-auto mb-3 mb-lg-0 me-lg-3 force-rtl"
                   role="search"
                   action="{% url 'instrument-list' %}"
                   method="get">

--- a/web-app/django/VIM/templates/instruments/includes/paginationOptions.html
+++ b/web-app/django/VIM/templates/instruments/includes/paginationOptions.html
@@ -39,12 +39,12 @@
         </a>
       </li>
     {% endif %}
-    <li class="page-item align-self-center">
+    <li class="page-item align-self-center force-rtl">
       <span class="current p-2">
         Page
         <span class="page-number">{{ page_obj.number }}</span>
         of
-        {{ page_obj.paginator.num_pages }}
+        <span>{{ page_obj.paginator.num_pages }}</span>
       </span>
     </li>
     {% if page_obj.has_next %}

--- a/web-app/frontend/assets/scss/global.scss
+++ b/web-app/frontend/assets/scss/global.scss
@@ -71,4 +71,9 @@ body {
     direction: ltr !important;
     text-align: left !important;
   }
+
+  .force-rtl {
+    direction: rtl !important;
+    text-align: right !important;
+  }
 }


### PR DESCRIPTION
- Add new SCSS utilities for handling RTL exceptions when `direction: ltr`
- Apply the new force-rtl helpers to pagination and the navbar search to prevent numbering issues and correct text direction behavior.


Corrected examples:
<img width="993" height="277" alt="Screenshot 2025-12-05 at 4 38 18 PM" src="https://github.com/user-attachments/assets/675bd123-ec58-4f11-8fc4-25608e2d9ecf" />

<img width="835" height="198" alt="Screenshot 2025-12-05 at 4 00 29 PM" src="https://github.com/user-attachments/assets/af270544-ea17-40fe-9f11-e95256e9cbf6" />
