### PR TITLE
fix: make addName modal rtl-friendly

### DIFF
--- a/web-app/django/VIM/templates/instruments/includes/addName.html
+++ b/web-app/django/VIM/templates/instruments/includes/addName.html
@@ -10,9 +10,9 @@
     <div class="modal-content">
       <div class="modal-header">
         <h5 class="modal-title" id="addNameModalLabel">
-          <span>Add New Name:<span id="instrumentNameInModal" class="notranslate m-2"></span></span>
+          <span>Add New Name: <span id="instrumentNameInModal" class="notranslate m-1"></span></span>
           <br />
-          <small>Wikidata ID:<span id="instrumentWikidataIdInModal" class="notranslate m-2"></span></small>
+          <small>Wikidata ID: <span id="instrumentWikidataIdInModal" class="notranslate m-1"></span></small>
         </h5>
         <div class="flex-grow-1"></div>
         <button type="button"


### PR DESCRIPTION
- Add `flex-grow-1` spacer to keep the close button aligned correctly in RTL layouts
- Update wording to avoid `notranslate` in the middle of sentences for smoother translations

Before:
<img width="975" height="433" alt="before" src="https://github.com/user-attachments/assets/cf68944b-6b50-4575-b74c-e3b08aa5662b" />

After:
<img width="811" height="420" alt="After" src="https://github.com/user-attachments/assets/0a02a869-25bd-4771-a848-c6dbf644f67b" />


