### PR TITLE
feat: allow users to customize AND/OR logic in facet selection

### DIFF
--- a/web-app/django/VIM/apps/instruments/views/instrument_list.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_list.py
@@ -190,6 +190,14 @@ class InstrumentList(TemplateView):
         # Add URL building helpers for preserving search query in HBS facet links
         context["current_search_query"] = search_query
 
+        # Add url for hbs logic
+        context["hbs_logic_urls"] = {
+            "AND": "?"
+            + urlencode(self.build_params(hbs_facet, search_query, "AND"), doseq=True),
+            "OR": "?"
+            + urlencode(self.build_params(hbs_facet, search_query, "OR"), doseq=True),
+        }
+
         # Enhanced HBS facets with proper URLs that preserve search query
         enhanced_hbs_facets = []
         for facet in hbs_facet_list:

--- a/web-app/django/VIM/templates/instruments/index.html
+++ b/web-app/django/VIM/templates/instruments/index.html
@@ -58,6 +58,18 @@
           {% endif %}
           <div class="info-block bg-light h-auto p-2 mb-3">
             <h4>Hornbostel-Sachs Classification</h4>
+            <div class="d-flex justify-content-end mb-2">
+              <div class="btn-group btn-group-sm" role="group">
+                <a href="{{ hbs_logic_urls.AND }}"
+                   class="btn {% if hbs_logic == 'AND' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                  AND
+                </a>
+                <a href="{{ hbs_logic_urls.OR }}"
+                   class="btn {% if hbs_logic == 'OR' %}btn-primary{% else %}btn-outline-primary{% endif %}">
+                  OR
+                </a>
+              </div>
+            </div>
             <hr class="mt-0" />
             <ul class="list-group">
               {% for hbs_facet_item in hbs_facets %}


### PR DESCRIPTION
- Add ability to generate Solr queries using AND/OR across multiple HBS facets
- Add support for selecting multiple HBS facets in the UI by updating the URL-building workflow in the view
- Add AND/OR selection controls to the UI
- Fix overflow issue in the selected-tag UI element

resolves #453 

Selection sidebar:
<img width="367" height="540" alt="sidebar" src="https://github.com/user-attachments/assets/2f5be9e8-a7d1-44ca-a3b9-27273738fccf" />


URL example:
<img width="477" height="48" alt="url" src="https://github.com/user-attachments/assets/abeea827-f49b-453e-b5e1-c99be15a5b81" />
