### PR TITLE
feat: update index language buttons with Google Translate selection

### DIFF
--- a/web-app/django/VIM/apps/instruments/views/instrument_list.py
+++ b/web-app/django/VIM/apps/instruments/views/instrument_list.py
@@ -105,10 +105,21 @@ class InstrumentList(TemplateView):
         Returns:
             str: The English label of the active language
         """
-        language_en = self.request.GET.get("language")
-        if language_en:
-            return language_en
-        return self.request.session.get("active_language_en", settings.DEFAULT_LANGUAGE)
+        language_param = self.request.GET.get("language") or self.request.session.get(
+            "active_language_en"
+        )
+
+        if language_param:
+            # Check if the language is an English label
+            try:
+                lang_obj = Language.objects.get(en_label__iexact=language_param)
+                return lang_obj.en_label
+
+            except Language.DoesNotExist:
+                pass
+
+        # Return the defult if nothing matches
+        return settings.DEFAULT_LANGUAGE
 
     def get_active_language(self) -> Language:
         """

--- a/web-app/django/VIM/templates/main/index.html
+++ b/web-app/django/VIM/templates/main/index.html
@@ -50,7 +50,8 @@
           </div>
           <div class="row">
             <div class="col-6">
-              <a href="{% url "instrument-list" %}?language=English">
+              <a class="dynamic-language-link"
+                 href="{% url 'instrument-list' %}?language=English">
                 <button class="btn btn-warning rounded-pill start-btn en-site-btn desktop">
                   Visit English Site
                 </button>
@@ -80,7 +81,8 @@
               <br />
               Explore, share, connect musical instruments in every language.
             </p>
-            <a href="{% url "instrument-list" %}?language=English">
+            <a class="dynamic-language-link"
+               href="{% url 'instrument-list' %}?language=English">
               <button class="btn btn-warning rounded-pill start-btn en-site-btn mobile">
                 Visit English Site
               </button>

--- a/web-app/frontend/src/GoogleTranslate.ts
+++ b/web-app/frontend/src/GoogleTranslate.ts
@@ -173,6 +173,9 @@ function getGTLanguage(googleSelect: HTMLSelectElement) {
 }
 
 function updateLanguageButtons(langCode: string) {
+  // Skip French languages
+  if (langCode.toLowerCase().includes('fr')) return;
+
   let displayName = langCode;
 
   // Convert code → English display name

--- a/web-app/frontend/src/GoogleTranslate.ts
+++ b/web-app/frontend/src/GoogleTranslate.ts
@@ -58,6 +58,7 @@ function googleTranslateElementInit() {
       'google_translate_element',
     );
     customizeGoogleTranslate();
+    attachGTLanguageListener();
   } catch (error) {
     console.error('Google Translate initialization failed:', error);
     setTimeout(googleTranslateElementInit, 200);
@@ -92,6 +93,29 @@ function customizeGoogleTranslate() {
 
   // Set up observer to watch for Google Translate widget changes
   watchGTDefaultText(googleSelect);
+}
+
+function attachGTLanguageListener() {
+  const googleSelect =
+    document.querySelector<HTMLSelectElement>('.goog-te-combo');
+
+  if (!googleSelect) {
+    setTimeout(attachGTLanguageListener, 100);
+    return;
+  }
+
+  // Wait to GT set its current value (from another tab)
+  setTimeout(() => {
+    if (googleSelect.value) {
+      updateLanguageButtons(googleSelect.value);
+    }
+  }, 500);
+
+  // Update when user changes language
+  googleSelect.addEventListener('change', () => {
+    if (!googleSelect.value) return;
+    updateLanguageButtons(googleSelect.value);
+  });
 }
 
 // Watch for the default text of the Google Translate widget to be "Select Language"
@@ -146,6 +170,39 @@ function clearGTLanguage() {
 
 function getGTLanguage(googleSelect: HTMLSelectElement) {
   return readCookie('googtrans');
+}
+
+function updateLanguageButtons(langCode: string) {
+  let displayName = langCode;
+
+  // Convert code → English display name
+  if (typeof Intl?.DisplayNames === 'function') {
+    const dn = new Intl.DisplayNames(['en'], { type: 'language' });
+    displayName = dn.of(langCode) ?? langCode;
+  }
+
+  document
+    .querySelectorAll<HTMLAnchorElement>('a.dynamic-language-link')
+    .forEach((link) => {
+      try {
+        const url = new URL(link.href, window.location.origin);
+        // Put DISPLAY NAME in URL
+        url.searchParams.set('language', displayName);
+        link.href = url.pathname + url.search + url.hash;
+      } catch {}
+
+      let btn = link.querySelector<HTMLButtonElement>('.en-site-btn');
+
+      if (btn) {
+        // Remove cookie Listeners
+        const newBtn = btn.cloneNode(true) as HTMLButtonElement;
+        btn.replaceWith(newBtn);
+        btn = newBtn;
+      }
+      if (!btn) return;
+
+      btn.textContent = `Visit ${displayName} Site`;
+    });
 }
 
 // Export the initialization function so it's globally accessible for backwards compatibility


### PR DESCRIPTION

- Change the link and text of Visit English Site button when a language is set by Google Translate
- Ensure the button reflects Google Translate selection even if chosen in another tab
- Prevent old event listeners from firing by cloning buttons before updating
- Do not update button text or cookies if the language is French
- Use English as a fallback for selected language if conversion fails

ref: #434

<img width="1370" height="660" alt="ex" src="https://github.com/user-attachments/assets/6bf6e8b8-2050-4ddc-8aeb-f5412a3bcca1" />

<img width="1149" height="513" alt="ex" src="https://github.com/user-attachments/assets/fb0c9f0e-0893-4359-80d2-5120a349f4e8" />

BEFORE: 
<img width="1219" height="560" alt="ex" src="https://github.com/user-attachments/assets/80b67b7c-7e99-4d4d-ac1b-184d6fe96a58" />
