### PR TITLE
refactor: refine verification status badge rendering

### DIFF
--- a/web-app/django/VIM/templates/instruments/detail.html
+++ b/web-app/django/VIM/templates/instruments/detail.html
@@ -161,7 +161,7 @@
                                   <span class="badge rounded-pill text-bg-gray">Unverified</span>
                                 {% elif names.label.verification_status == 'rejected' %}
                                   <span class="badge rounded-pill text-bg-danger">Rejected</span>
-                                {% else %}
+                                {% elif names.label.verification_status == 'under_review' %}
                                   <span class="badge rounded-pill text-bg-warning">Under Review</span>
                                 {% endif %}
                               </div>
@@ -242,7 +242,7 @@
                               <span class="badge rounded-pill text-bg-gray">Unverified</span>
                             {% elif names.label.verification_status == 'rejected' %}
                               <span class="badge rounded-pill text-bg-danger">Rejected</span>
-                            {% else %}
+                            {% elif names.label.verification_status == 'under_review' %}
                               <span class="badge rounded-pill text-bg-warning">Under Review</span>
                             {% endif %}
                           </div>


### PR DESCRIPTION
- to avoid `under review` status for a null label

<img width="628" height="396" alt="example" src="https://github.com/user-attachments/assets/3e0de1f3-58fb-4554-99ac-4f102ad1685f" />
