### PR TITLE
test(e2e): refactor Google Translate with config modes

### DIFF
--- a/web-app/frontend/tests/e2e/googleTranslate/desktop.spec.ts
+++ b/web-app/frontend/tests/e2e/googleTranslate/desktop.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '../../fixtures/pages';
 
-test.describe('Desktop Google Translate', () => {
-  test.use({ blockGoogleTranslate: false });
+test.use({ googleTranslateMode: 'stub' });
 
+test.describe('Desktop Google Translate', () => {
   test.beforeEach(async ({ homePage }) => {
     await homePage.goto();
   });

--- a/web-app/frontend/tests/e2e/googleTranslate/mobile.spec.ts
+++ b/web-app/frontend/tests/e2e/googleTranslate/mobile.spec.ts
@@ -1,8 +1,8 @@
 import { test, expect } from '../../fixtures/pages';
 
-test.describe('Mobile Google Translate', () => {
-  test.use({ blockGoogleTranslate: false });
+test.use({ googleTranslateMode: 'stub' });
 
+test.describe('Mobile Google Translate', () => {
   test.beforeEach(async ({ homePage }) => {
     await homePage.goto();
   });

--- a/web-app/frontend/tests/fixtures/google-translate-stub.js
+++ b/web-app/frontend/tests/fixtures/google-translate-stub.js
@@ -1,0 +1,116 @@
+(function () {
+  // Minimal deterministic Google Translate stub for E2E testing
+  window.google = window.google || {};
+  window.google.translate = window.google.translate || {};
+
+  // Cookie management
+  function setCookie(name, value) {
+    document.cookie = name + '=' + value + '; path=/; SameSite=Lax';
+  }
+
+  function getCookie(name) {
+    const match = document.cookie.match(
+      new RegExp(
+        '(?:^|; )' + name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') + '=([^;]*)',
+      ),
+    );
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  // Apply language change and update DOM
+  function applyLanguage(langCode) {
+    if (langCode === 'fr') {
+      setCookie('googtrans', '/en/fr');
+      document.documentElement.setAttribute('lang', 'fr');
+    } else if (langCode === 'en' || langCode === '') {
+      setCookie('googtrans', '');
+      document.documentElement.setAttribute('lang', 'en');
+    }
+  }
+
+  // Initialize language attribute from cookie immediately
+  (function initLangAttribute() {
+    const googtrans = getCookie('googtrans');
+    if (googtrans && googtrans.includes('/fr')) {
+      document.documentElement.setAttribute('lang', 'fr');
+    } else {
+      document.documentElement.setAttribute('lang', 'en');
+    }
+  })();
+
+  // TranslateElement constructor
+  function TranslateElement(options, elementId) {
+    const self = this;
+
+    // Function to create and inject the widget
+    function createWidget() {
+      const container = document.getElementById(elementId);
+      if (!container) {
+        // Retry if container not found
+        setTimeout(createWidget, 50);
+        return;
+      }
+
+      // Clear any existing content
+      container.innerHTML = '';
+
+      // Create widget structure
+      const gadget = document.createElement('div');
+      gadget.className = 'goog-te-gadget';
+
+      const select = document.createElement('select');
+      select.className = 'goog-te-combo';
+      select.setAttribute('aria-label', 'Language Translate Widget');
+
+      // Add options
+      const optionData = [
+        { value: '', text: 'Select Language' },
+        { value: 'en', text: 'English' },
+        { value: 'fr', text: 'French' },
+      ];
+
+      optionData.forEach((data) => {
+        const option = document.createElement('option');
+        option.value = data.value;
+        option.text = data.text;
+        select.appendChild(option);
+      });
+
+      // Set initial value from cookie
+      const currentCookie = getCookie('googtrans');
+      if (currentCookie && currentCookie.includes('/fr')) {
+        select.value = 'fr';
+      } else {
+        select.value = 'en';
+      }
+
+      // Handle change events
+      select.addEventListener('change', function () {
+        const selectedValue = this.value;
+        applyLanguage(selectedValue);
+      });
+
+      // Append to DOM
+      gadget.appendChild(select);
+      container.appendChild(gadget);
+    }
+
+    // Create widget immediately if DOM is ready, otherwise wait
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', createWidget);
+    } else {
+      // Use setTimeout to ensure it runs after current call stack
+      setTimeout(createWidget, 0);
+    }
+  }
+
+  // Static properties
+  TranslateElement.InlineLayout = {
+    HORIZONTAL: 0,
+    SIMPLE: 1,
+    VERTICAL: 2,
+  };
+
+  // Export to window
+  window.google.translate.TranslateElement = TranslateElement;
+})();

--- a/web-app/frontend/tests/fixtures/pages.ts
+++ b/web-app/frontend/tests/fixtures/pages.ts
@@ -1,4 +1,6 @@
 import { test as base } from '@playwright/test';
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import {
   HomePage,
   LoginPage,
@@ -17,26 +19,37 @@ type PageFixtures = {
 
 type TestOptions = {
   /**
-   * When enabled, aborts the external Google Translate script request to avoid
-   * rate limiting (HTTP 429) during E2E runs.
+   * Controls how Google Translate is handled during E2E tests:
+   * - 'block': Completely blocks Google Translate requests (default)
+   * - 'stub': Provides a deterministic Google Translate stub for testing
+   * - 'allow': Allows real Google Translate to load
    */
-  blockGoogleTranslate: boolean;
+  googleTranslateMode: 'block' | 'stub' | 'allow';
 };
 
 export const test = base.extend<PageFixtures & TestOptions>({
-  blockGoogleTranslate: [true, { option: true }],
+  googleTranslateMode: ['block', { option: true }],
 
-  page: async ({ page, blockGoogleTranslate }, use) => {
-    if (blockGoogleTranslate) {
-      // Keep the <script> tag happy without hitting Google's servers.
+  page: async ({ page, googleTranslateMode }, use) => {
+    if (googleTranslateMode === 'block') {
+      // Completely block Google Translate requests
+      await page.route('**/translate_a/element.js*', async (route) => {
+        await route.abort('blockedbyclient');
+      });
+    } else if (googleTranslateMode === 'stub') {
+      // Load the deterministic stub from external file
+      const stubPath = join(__dirname, 'google-translate-stub.js');
+      const stubCode = readFileSync(stubPath, 'utf-8');
+
       await page.route('**/translate_a/element.js*', async (route) => {
         await route.fulfill({
           status: 200,
           contentType: 'application/javascript; charset=utf-8',
-          body: '',
+          body: stubCode,
         });
       });
     }
+    // If googleTranslateMode === 'allow', do nothing and let real Google Translate load
 
     await use(page);
   },


### PR DESCRIPTION
- Replace `blockGoogleTranslate` with `googleTranslateMode` enum
- Add three modes: 'block' (default), 'stub', and 'allow'
- Add `google-translate-stub.js` to mimic basic GT functionalities
- Update GT tests to use 'stub' mode
- Non-GT tests now block GT requests entirely
- This should make the GT E2E test more stable

refs: #494

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors E2E Google Translate handling to be configurable and stable.
> 
> - Replace `blockGoogleTranslate` with `googleTranslateMode` option in `tests/fixtures/pages.ts` supporting `'block'`, `'stub'`, and `'allow'`
> - Add request routing: block GT script, fulfill with local stub (`google-translate-stub.js`), or allow real script
> - New `tests/fixtures/google-translate-stub.js` implementing minimal `google.translate.TranslateElement`, cookie-driven lang switching, and deterministic DOM updates
> - Update desktop and mobile GT specs to `test.use({ googleTranslateMode: 'stub' })`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b6260984f2c71ff80f2e9bda95cbb80808eaa02. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->