### PR TITLE
fix(ci): disable semantic-release success comments

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -11,6 +11,6 @@
         "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
       }
     ],
-    "@semantic-release/github"
+    ["@semantic-release/github", { "successComment": false }]
   ]
 }


### PR DESCRIPTION
This is to fix the error in https://github.com/DDMAL/UMIL/actions/runs/21882801584. `@semantic-release/github` tries to comment on the resolved PRs/issues. The GitHub API returned undefined for one of those lookups (possibly due to pagination, a deleted PR, or a rate limit), and destructuring repository from undefined throws the error. Set `successComment` to `false` to skip commenting.