### PR TITLE
add guideline link to AddName.html

### DIFF
--- a/web-app/django/VIM/templates/instruments/includes/addName.html
+++ b/web-app/django/VIM/templates/instruments/includes/addName.html
@@ -34,6 +34,14 @@
               <button type="button" class="btn btn-secondary" id="addRowBtn">
                 Add another row
               </button>
+              <div class="mt-3 pt-3 border-top">
+                <small>
+                  <a href="https://github.com/DDMAL/UMIL/wiki/Adding-a-New-Instrument-Name"
+                     class="notranslate m-1">
+                    📖 Guideline: Adding a New Instrument Name
+                  </a>
+                </small>
+              </div>
             </div>
           </div>
           <!-- Row for 'Publish' button -->


### PR DESCRIPTION
Added a link to the Wiki guideline below the "Add another row" button to help users with instrument name conventions. Related to #512.

<img width="1333" height="660" alt="2026-02-13_add inst name on UMIL" src="https://github.com/user-attachments/assets/7d90a5e5-8031-4b95-8ac9-5448109b5d5f" />

